### PR TITLE
BlockOut now uses GlStateManager, fixes texture bind bug that require…

### DIFF
--- a/src/main/java/com/blockout/Pane.java
+++ b/src/main/java/com/blockout/Pane.java
@@ -279,14 +279,10 @@ public class Pane extends Gui
     {
         if (visible)
         {
-            GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
             drawSelf(mx, my);
-            GL11.glPopAttrib();
 
             if (debugging)
             {
-                GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
-
                 boolean isMouseOver = isPointInPane(mx, my);
                 int color = isMouseOver ? 0xFF00FF00 : 0xFF0000FF;
 
@@ -297,8 +293,6 @@ public class Pane extends Gui
                     int stringWidth = mc.fontRendererObj.getStringWidth(id);
                     mc.fontRendererObj.drawString(id, x + getWidth() - stringWidth, y + getHeight() - mc.fontRendererObj.FONT_HEIGHT, color);
                 }
-
-                GL11.glPopAttrib();
             }
         }
     }

--- a/src/main/java/com/blockout/Render.java
+++ b/src/main/java/com/blockout/Render.java
@@ -1,5 +1,6 @@
 package com.blockout;
 
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
@@ -56,9 +57,9 @@ public final class Render
         WorldRenderer worldrenderer = tessellator.getWorldRenderer();
 
         worldrenderer.begin(GL11.GL_LINE_LOOP, DefaultVertexFormats.POSITION);
-        GL11.glDisable(GL11.GL_TEXTURE_2D);
+        GlStateManager.disableTexture2D();
         GL11.glLineWidth(lineWidth);
-        GL11.glColor4f(r, g, b, a);
+        GlStateManager.color(r, g, b, a);
 
         //Since our points do not have any u,v this seems to be the correct code
         worldrenderer.pos(x1, y2, 0.0D).endVertex();
@@ -67,6 +68,6 @@ public final class Render
         worldrenderer.pos(x1, y1, 0.0D).endVertex();
 
         tessellator.draw();
-        GL11.glEnable(GL11.GL_TEXTURE_2D);
+        GlStateManager.enableTexture2D();
     }
 }

--- a/src/main/java/com/blockout/Screen.java
+++ b/src/main/java/com/blockout/Screen.java
@@ -6,7 +6,6 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.GlStateManager;
 import org.lwjgl.input.Keyboard;
-import org.lwjgl.opengl.GL11;
 
 /**
  * Wraps MineCrafts GuiScreen for BlockOut's Window

--- a/src/main/java/com/blockout/Screen.java
+++ b/src/main/java/com/blockout/Screen.java
@@ -4,6 +4,7 @@ import com.blockout.views.Window;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.GlStateManager;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
@@ -49,10 +50,10 @@ public class Screen extends GuiScreen
 
         setScale(mc);
 
-        GL11.glPushMatrix();
-        GL11.glTranslatef(x, y, 0);
+        GlStateManager.pushMatrix();
+        GlStateManager.translate(x, y, 0);
         window.draw(mx - x, my - y);
-        GL11.glPopMatrix();
+        GlStateManager.popMatrix();
     }
 
     @Override

--- a/src/main/java/com/blockout/View.java
+++ b/src/main/java/com/blockout/View.java
@@ -2,7 +2,6 @@ package com.blockout;
 
 import com.blockout.views.Window;
 import net.minecraft.client.renderer.GlStateManager;
-import org.lwjgl.opengl.GL11;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/blockout/View.java
+++ b/src/main/java/com/blockout/View.java
@@ -1,6 +1,7 @@
 package com.blockout;
 
 import com.blockout.views.Window;
+import net.minecraft.client.renderer.GlStateManager;
 import org.lwjgl.opengl.GL11;
 
 import java.util.ArrayList;
@@ -129,12 +130,12 @@ public class View extends Pane
     protected void drawSelf(int mx, int my)
     {
         //  Translate the drawing origin to our x,y
-        GL11.glPushMatrix();
+        GlStateManager.pushMatrix();
 
         int paddedX = x + padding;
         int paddedY = y + padding;
 
-        GL11.glTranslatef((float) paddedX, (float) paddedY, 0);
+        GlStateManager.translate((float) paddedX, (float) paddedY, 0);
 
         //  Translate Mouse into the View
         int drawX = mx - paddedX;
@@ -142,7 +143,7 @@ public class View extends Pane
 
         children.stream().filter(this::childIsVisible).forEach(child -> child.draw(drawX, drawY));
 
-        GL11.glPopMatrix();
+        GlStateManager.popMatrix();
     }
 
     @Override

--- a/src/main/java/com/blockout/controls/ButtonImage.java
+++ b/src/main/java/com/blockout/controls/ButtonImage.java
@@ -2,6 +2,7 @@ package com.blockout.controls;
 
 import com.blockout.Alignment;
 import com.blockout.PaneParams;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Tuple;
@@ -585,16 +586,16 @@ public class ButtonImage extends Button
         this.mc.getTextureManager().bindTexture(texture);
         if (this.enabled || this.imageDisabled != null)
         {
-            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+            GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
         }
         else
         {
-            GL11.glColor4f(HALF, HALF, HALF, 1.0F);
+            GlStateManager.color(HALF, HALF, HALF, 1.0F);
         }
 
-        GL11.glEnable(GL11.GL_BLEND);
-        OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
-        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+        GlStateManager.enableBlend();
+        GlStateManager.tryBlendFuncSeparate(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
+        GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
     }
 
     /**
@@ -629,10 +630,10 @@ public class ButtonImage extends Button
                 offsetY += (getHeight() - getTextHeight()) / 2;
             }
 
-            GL11.glPushMatrix();
-            GL11.glTranslatef((float) textScale, (float) textScale, (float) textScale);
+            GlStateManager.pushMatrix();
+            GlStateManager.translate((float) textScale, (float) textScale, (float) textScale);
             mc.fontRendererObj.drawString(label, (float) (getX() + offsetX), (float) (getY() + offsetY), color, shadow);
-            GL11.glPopMatrix();
+            GlStateManager.popMatrix();
         }
     }
 }

--- a/src/main/java/com/blockout/controls/ButtonImage.java
+++ b/src/main/java/com/blockout/controls/ButtonImage.java
@@ -3,7 +3,6 @@ package com.blockout.controls;
 import com.blockout.Alignment;
 import com.blockout.PaneParams;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Tuple;
 import org.lwjgl.opengl.GL11;

--- a/src/main/java/com/blockout/controls/ButtonVanilla.java
+++ b/src/main/java/com/blockout/controls/ButtonVanilla.java
@@ -63,7 +63,7 @@ public class ButtonVanilla extends Button
     public void drawSelf(int mx, int my)
     {
         mc.renderEngine.bindTexture(TEXTURE);
-        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
 
         boolean isMouseOver = isPointInPane(mx, my);
 

--- a/src/main/java/com/blockout/controls/Image.java
+++ b/src/main/java/com/blockout/controls/Image.java
@@ -132,10 +132,11 @@ public class Image extends Pane
     {
         // Some other texture must need to be ticked, I tried ticking the current one.
         // This fixes the problem, even if you put it after the draw call. So I guess I'll keep it.
-        this.mc.getTextureManager().tick();
-        this.mc.getTextureManager().bindTexture(resourceLocation);
 
         GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+
+        this.mc.getTextureManager().bindTexture(resourceLocation);
+
         //Draw
         drawModalRectWithCustomSizedTexture(x, y,
                 imageOffsetX, imageOffsetY,

--- a/src/main/java/com/blockout/controls/Label.java
+++ b/src/main/java/com/blockout/controls/Label.java
@@ -1,6 +1,7 @@
 package com.blockout.controls;
 
 import com.blockout.PaneParams;
+import net.minecraft.client.renderer.GlStateManager;
 import org.lwjgl.opengl.GL11;
 
 /**
@@ -98,11 +99,11 @@ public class Label extends AbstractTextElement
             offsetY = (getHeight() - getTextHeight()) / 2;
         }
 
-        GL11.glPushMatrix();
-        GL11.glTranslated((double) (getX() + offsetX), (double) (getY() + offsetY), 0);
-        GL11.glScalef((float) scale, (float) scale, (float) scale);
+        GlStateManager.pushMatrix();
+        GlStateManager.translate((double) (getX() + offsetX), (double) (getY() + offsetY), 0);
+        GlStateManager.scale((float) scale, (float) scale, (float) scale);
         mc.renderEngine.bindTexture(TEXTURE);
         mc.fontRendererObj.drawString(labelText, 0, 0, color, shadow);
-        GL11.glPopMatrix();
+        GlStateManager.popMatrix();
     }
 }

--- a/src/main/java/com/blockout/controls/Label.java
+++ b/src/main/java/com/blockout/controls/Label.java
@@ -2,7 +2,6 @@ package com.blockout.controls;
 
 import com.blockout.PaneParams;
 import net.minecraft.client.renderer.GlStateManager;
-import org.lwjgl.opengl.GL11;
 
 /**
  * BlockOut label pane. Used to render a piece of text.

--- a/src/main/java/com/blockout/controls/Text.java
+++ b/src/main/java/com/blockout/controls/Text.java
@@ -1,6 +1,7 @@
 package com.blockout.controls;
 
 import com.blockout.PaneParams;
+import net.minecraft.client.renderer.GlStateManager;
 import org.lwjgl.opengl.GL11;
 
 import java.util.ArrayList;
@@ -157,12 +158,12 @@ public class Text extends AbstractTextElement
                 }
             }
 
-            GL11.glPushMatrix();
-            GL11.glTranslatef((float) (getX() + offsetX), (float) (getY() + offsetY), 0);
-            GL11.glScalef((float) scale, (float) scale, (float) scale);
+            GlStateManager.pushMatrix();
+            GlStateManager.translate((float) (getX() + offsetX), (float) (getY() + offsetY), 0);
+            GlStateManager.scale((float) scale, (float) scale, (float) scale);
             mc.renderEngine.bindTexture(TEXTURE);
             mc.fontRendererObj.drawString(s, 0, 0, textColor, shadow);
-            GL11.glPopMatrix();
+            GlStateManager.popMatrix();
 
             offsetY += getLineHeight() + scaledLinespace;
 

--- a/src/main/java/com/blockout/controls/Text.java
+++ b/src/main/java/com/blockout/controls/Text.java
@@ -2,7 +2,6 @@ package com.blockout.controls;
 
 import com.blockout.PaneParams;
 import net.minecraft.client.renderer.GlStateManager;
-import org.lwjgl.opengl.GL11;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/com/blockout/controls/TextField.java
+++ b/src/main/java/com/blockout/controls/TextField.java
@@ -4,6 +4,7 @@ import com.blockout.Pane;
 import com.blockout.PaneParams;
 import com.blockout.View;
 import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
@@ -278,10 +279,10 @@ public class TextField extends Pane
             }
 
             Tessellator tessellator = Tessellator.getInstance();
-            GL11.glColor4f(0.0F, 0.0F, 255.0F, 255.0F);
-            GL11.glDisable(GL11.GL_TEXTURE_2D);
-            GL11.glEnable(GL11.GL_COLOR_LOGIC_OP);
-            GL11.glLogicOp(GL11.GL_OR_REVERSE);
+            GlStateManager.color(0.0F, 0.0F, 255.0F, 255.0F);
+            GlStateManager.disableTexture2D();
+            GlStateManager.enableColorLogic();
+            GlStateManager.colorLogicOp(GL11.GL_OR_REVERSE);
             WorldRenderer worldrenderer = tessellator.getWorldRenderer();
 
             // There are several to choose from, look at DefaultVertexFormats for more info
@@ -294,8 +295,8 @@ public class TextField extends Pane
             worldrenderer.pos((double) selectionEndX, (double) drawY - 1, 0.0D).endVertex();
             worldrenderer.pos((double) selectionStartX, (double) drawY - 1, 0.0D).endVertex();
             tessellator.draw();
-            GL11.glDisable(GL11.GL_COLOR_LOGIC_OP);
-            GL11.glEnable(GL11.GL_TEXTURE_2D);
+            GlStateManager.disableColorLogic();
+            GlStateManager.enableTexture2D();
         }
     }
 

--- a/src/main/java/com/blockout/controls/TextFieldVanilla.java
+++ b/src/main/java/com/blockout/controls/TextFieldVanilla.java
@@ -3,7 +3,6 @@ package com.blockout.controls;
 import com.blockout.PaneParams;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.ChatAllowedCharacters;
-import org.lwjgl.opengl.GL11;
 
 /**
  * Mimics Vanilla text fields.

--- a/src/main/java/com/blockout/controls/TextFieldVanilla.java
+++ b/src/main/java/com/blockout/controls/TextFieldVanilla.java
@@ -1,6 +1,7 @@
 package com.blockout.controls;
 
 import com.blockout.PaneParams;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.ChatAllowedCharacters;
 import org.lwjgl.opengl.GL11;
 
@@ -80,15 +81,15 @@ public class TextFieldVanilla extends TextField
             drawRect(x - 1, y - 1, x + width + 1, y + height + 1, backgroundOuterColor);
             drawRect(x, y, x + width, y + height, backgroundInnerColor);
 
-            GL11.glPushMatrix();
-            GL11.glTranslatef(4, (float) ((height - 8) / 2.0), 0);
+            GlStateManager.pushMatrix();
+            GlStateManager.translate(4, (float) ((height - 8) / 2.0), 0);
         }
 
         super.drawSelf(mx, my);
 
         if (backgroundEnabled)
         {
-            GL11.glPopMatrix();
+            GlStateManager.popMatrix();
         }
     }
 

--- a/src/main/java/com/blockout/views/ScrollingContainer.java
+++ b/src/main/java/com/blockout/views/ScrollingContainer.java
@@ -4,7 +4,6 @@ import com.blockout.Pane;
 import com.blockout.PaneParams;
 import com.blockout.View;
 import net.minecraft.client.renderer.GlStateManager;
-import org.lwjgl.opengl.GL11;
 
 /**
  * Basic scrollable pane.

--- a/src/main/java/com/blockout/views/ScrollingContainer.java
+++ b/src/main/java/com/blockout/views/ScrollingContainer.java
@@ -3,6 +3,7 @@ package com.blockout.views;
 import com.blockout.Pane;
 import com.blockout.PaneParams;
 import com.blockout.View;
+import net.minecraft.client.renderer.GlStateManager;
 import org.lwjgl.opengl.GL11;
 
 /**
@@ -106,10 +107,10 @@ public class ScrollingContainer extends View
         scissorsStart();
 
         //  Translate the scroll
-        GL11.glPushMatrix();
-        GL11.glTranslatef(0, -scrollY, 0);
+        GlStateManager.pushMatrix();
+        GlStateManager.translate(0, -scrollY, 0);
         super.drawSelf(mx, my + scrollY);
-        GL11.glPopMatrix();
+        GlStateManager.popMatrix();
 
         scissorsEnd();
     }


### PR DESCRIPTION
Brings BlockOut up to date with 1.8 rendering engine methods, fixes various issues with it losing/setting state incorrectly.  Fixes texture bind bug that required workaround in Image.java (when the same texture was used repeatedly by sequential items).

Should play more nicely with rendering in general.

Review please @Minecolonies/maintainers