### PR TITLE
Scarecrow rendering fixed, stop exception.

### DIFF
--- a/src/main/java/com/minecolonies/client/render/TileEntityScarecrowRenderer.java
+++ b/src/main/java/com/minecolonies/client/render/TileEntityScarecrowRenderer.java
@@ -80,13 +80,8 @@ public class TileEntityScarecrowRenderer extends TileEntitySpecialRenderer<Scare
     @Override
     public void renderTileEntityAt(@NotNull ScarecrowTileEntity te, double posX, double posY, double posZ, float partialTicks, int destroyStage)
     {
-        //In the case of worldLags tileEntities may sometimes disappear.
-        if(!(getWorld().getBlockState(te.getPos()) instanceof BlockHutField))
-        {
-            return;
-        }
 
-        final EnumFacing facing = getWorld().getBlockState(te.getPos()).getValue(BlockHutField.FACING);
+
 
         //Store the transformation
         GlStateManager.pushMatrix();
@@ -97,19 +92,25 @@ public class TileEntityScarecrowRenderer extends TileEntitySpecialRenderer<Scare
 
         GlStateManager.rotate(ROTATION, XROTATIONOFFSET, YROTATIONOFFSET, ZROTATIONOFFSET);
 
-        switch (facing)
+
+        //In the case of worldLags tileEntities may sometimes disappear.
+        if(getWorld().getBlockState(te.getPos()) instanceof BlockHutField)
         {
-            case EAST:
-                GlStateManager.rotate((float) (BASIC_ROTATION * ROTATE_EAST), 0, 1, 0);
-                break;
-            case SOUTH:
-                GlStateManager.rotate((float) (BASIC_ROTATION * ROTATE_SOUTH), 0, 1, 0);
-                break;
-            case WEST:
-                GlStateManager.rotate((float) (BASIC_ROTATION * ROTATE_WEST), 0, 1, 0);
-                break;
-            default:
-                //don't rotate at all.
+            final EnumFacing facing = getWorld().getBlockState(te.getPos()).getValue(BlockHutField.FACING);
+            switch (facing)
+            {
+                case EAST:
+                    GlStateManager.rotate((float) (BASIC_ROTATION * ROTATE_EAST), 0, 1, 0);
+                    break;
+                case SOUTH:
+                    GlStateManager.rotate((float) (BASIC_ROTATION * ROTATE_SOUTH), 0, 1, 0);
+                    break;
+                case WEST:
+                    GlStateManager.rotate((float) (BASIC_ROTATION * ROTATE_WEST), 0, 1, 0);
+                    break;
+                default:
+                    //don't rotate at all.
+            }
         }
 
         this.model.render((float) SIZERATIO);

--- a/src/main/java/com/minecolonies/client/render/TileEntityScarecrowRenderer.java
+++ b/src/main/java/com/minecolonies/client/render/TileEntityScarecrowRenderer.java
@@ -88,9 +88,9 @@ public class TileEntityScarecrowRenderer extends TileEntitySpecialRenderer<Scare
         this.bindTexture(getResourceLocation(te));
 
         GlStateManager.rotate(ROTATION, XROTATIONOFFSET, YROTATIONOFFSET, ZROTATIONOFFSET);
-        
+
         //In the case of worldLags tileEntities may sometimes disappear.
-        if(getWorld().getBlockState(te.getPos()) instanceof BlockHutField)
+        if(getWorld().getBlockState(te.getPos()).getBlock() instanceof BlockHutField)
         {
             final EnumFacing facing = getWorld().getBlockState(te.getPos()).getValue(BlockHutField.FACING);
             switch (facing)

--- a/src/main/java/com/minecolonies/client/render/TileEntityScarecrowRenderer.java
+++ b/src/main/java/com/minecolonies/client/render/TileEntityScarecrowRenderer.java
@@ -80,9 +80,6 @@ public class TileEntityScarecrowRenderer extends TileEntitySpecialRenderer<Scare
     @Override
     public void renderTileEntityAt(@NotNull ScarecrowTileEntity te, double posX, double posY, double posZ, float partialTicks, int destroyStage)
     {
-
-
-
         //Store the transformation
         GlStateManager.pushMatrix();
         //Set viewport to tile entity position to render it
@@ -91,8 +88,7 @@ public class TileEntityScarecrowRenderer extends TileEntitySpecialRenderer<Scare
         this.bindTexture(getResourceLocation(te));
 
         GlStateManager.rotate(ROTATION, XROTATIONOFFSET, YROTATIONOFFSET, ZROTATIONOFFSET);
-
-
+        
         //In the case of worldLags tileEntities may sometimes disappear.
         if(getWorld().getBlockState(te.getPos()) instanceof BlockHutField)
         {

--- a/src/main/java/com/minecolonies/colony/Colony.java
+++ b/src/main/java/com/minecolonies/colony/Colony.java
@@ -762,7 +762,10 @@ public class Colony implements IColony
     {
         @Nullable List<AbstractBuilding> removedBuildings = null;
 
-        for (@NotNull AbstractBuilding building : buildings.values())
+        //Need this list, we may enter he while we add a building in the real world.
+        List<AbstractBuilding> tempBuildings = new ArrayList<>(buildings.values());
+
+        for (@NotNull AbstractBuilding building : tempBuildings)
         {
             final BlockPos loc = building.getLocation();
             if (event.world.isBlockLoaded(loc) && !building.isMatchingBlock(event.world.getBlockState(loc).getBlock()))

--- a/src/main/java/com/minecolonies/util/RecipeHandler.java
+++ b/src/main/java/com/minecolonies/util/RecipeHandler.java
@@ -45,8 +45,8 @@ public final class RecipeHandler
         GameRegistry.addRecipe(new ItemStack(ModBlocks.blockSubstitution, 16), "XXX", "X#X", "XXX", 'X', Blocks.planks, '#', ModItems.scanTool);
         GameRegistry.addRecipe(new ItemStack(ModBlocks.blockHutFarmer, 1), "XXX", "X#X", "XXX", 'X', Blocks.planks, '#', Items.wooden_hoe);
         GameRegistry.addRecipe(new ItemStack(ModBlocks.blockHutFarmer, 2), "XXX", "X#X", "XXX", 'X', Blocks.planks, '#', Items.stone_hoe);
-        GameRegistry.addRecipe(new ItemStack(ModBlocks.blockHutField, 1), " Y ", "X#X", " X ", 'X', Items.stick, '#', Items.leather_chestplate, 'Y', Blocks.hay_block);
-        GameRegistry.addRecipe(new ItemStack(Blocks.web, 1), "XXX", "XXX", "XXX", 'X', Items.string);
+        GameRegistry.addRecipe(new ItemStack(ModBlocks.blockHutField, 1), " Y ", "X#X", " X ", 'X', Items.stick, '#', Items.leather, 'Y', Blocks.hay_block);
+        GameRegistry.addRecipe(new ItemStack(Blocks.web, 1), "X X", " X ", "X X", 'X', Items.string);
 
         // Disabled for now
         // GameRegistry.addRecipe(new ItemStack(ModBlocks.blockBarrel, 1), "P P", "P P", " S ", 'P', Blocks.planks, 'S', Blocks.wooden_slab);


### PR DESCRIPTION

Review please @Minecolonies/maintainers

Sometimes may not find the scarecrow in the world, in this case don't rotate.
Sometimes when placing a building or removing it, minecraft crashes since the list may be iteratet at that moment.