### PR TITLE
Fixes #71 build tool sometimes places huts the wrong way

### DIFF
--- a/src/main/java/com/minecolonies/items/ItemBuildTool.java
+++ b/src/main/java/com/minecolonies/items/ItemBuildTool.java
@@ -27,13 +27,12 @@ public class ItemBuildTool extends AbstractItemMinecolonies
     @Override
     public EnumActionResult onItemUse(ItemStack stack, EntityPlayer playerIn, World worldIn, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ)
     {
-        if (!worldIn.isRemote)
+        if (worldIn.isRemote)
         {
-            return EnumActionResult.FAIL;
+            playerIn.addStat(ModAchievements.achievementWandOfbuilding);
+            MineColonies.proxy.openBuildToolWindow(pos.offset(facing));
+            return EnumActionResult.SUCCESS;
         }
-
-        playerIn.addStat(ModAchievements.achievementWandOfbuilding);
-        MineColonies.proxy.openBuildToolWindow(pos.offset(facing));
         return EnumActionResult.FAIL;
     }
 

--- a/src/main/java/com/minecolonies/items/ItemBuildTool.java
+++ b/src/main/java/com/minecolonies/items/ItemBuildTool.java
@@ -27,13 +27,13 @@ public class ItemBuildTool extends AbstractItemMinecolonies
     @Override
     public EnumActionResult onItemUse(ItemStack stack, EntityPlayer playerIn, World worldIn, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ)
     {
+        playerIn.addStat(ModAchievements.achievementWandOfbuilding);
         if (worldIn.isRemote)
         {
-            playerIn.addStat(ModAchievements.achievementWandOfbuilding);
             MineColonies.proxy.openBuildToolWindow(pos.offset(facing));
-            return EnumActionResult.SUCCESS;
         }
-        return EnumActionResult.FAIL;
+
+        return EnumActionResult.SUCCESS;
     }
 
     @NotNull


### PR DESCRIPTION
Closes #71 

# Changes proposed in this pull request:
- Fixes the build tool placing the huts the wrong way
- Fixes the build tool achievement.

Review please @Minecolonies/maintainers
