### PR TITLE
Fixing #160.  build tool crashes on building placement with a null/0 …

### DIFF
--- a/src/main/java/com/minecolonies/colony/ColonyManager.java
+++ b/src/main/java/com/minecolonies/colony/ColonyManager.java
@@ -81,7 +81,7 @@ public final class ColonyManager
 
         markDirty();
 
-        Log.getLogger().info("New Colony %d", colony.getID());
+        Log.getLogger().info(String.format("New Colony Id: %d by %s", colony.getID(),player.getName()));
 
         return colony;
     }

--- a/src/main/java/com/minecolonies/colony/ColonyManager.java
+++ b/src/main/java/com/minecolonies/colony/ColonyManager.java
@@ -81,7 +81,7 @@ public final class ColonyManager
 
         markDirty();
 
-        Log.getLogger().info(String.format("New Colony Id: %d by %s", colony.getID(),player.getName()));
+        Log.getLogger().info(String.format("New Colony Id: %d by %s", colony.getID(), player.getName()));
 
         return colony;
     }
@@ -372,7 +372,7 @@ public final class ColonyManager
     @Nullable
     private static IColony getColonyByOwner(@Nullable UUID owner)
     {
-        if(owner == null)
+        if (owner == null)
         {
             return null;
         }

--- a/src/main/java/com/minecolonies/items/ItemBuildTool.java
+++ b/src/main/java/com/minecolonies/items/ItemBuildTool.java
@@ -45,6 +45,6 @@ public class ItemBuildTool extends AbstractItemMinecolonies
             MineColonies.proxy.openBuildToolWindow(null);
         }
 
-        return new ActionResult<>(EnumActionResult.PASS, itemStackIn);
+        return new ActionResult<>(EnumActionResult.SUCCESS, itemStackIn);
     }
 }

--- a/src/main/java/com/minecolonies/network/messages/BuildToolPlaceMessage.java
+++ b/src/main/java/com/minecolonies/network/messages/BuildToolPlaceMessage.java
@@ -169,6 +169,18 @@ public class BuildToolPlaceMessage implements IMessage, IMessageHandler<BuildToo
 
             if (building != null)
             {
+                if(building.getTileEntity()!= null)
+                {
+                    Colony colony=ColonyManager.getColony(world,buildPos);
+                    if(colony!=null)
+                    {
+                        building.getTileEntity().setColony(colony);
+                    }
+                    else
+                    {
+                        Log.getLogger().info("No colony for " + player.getName());
+                    }
+                }
                 building.setStyle(style);
                 building.setRotation(rotation);
             }

--- a/src/main/java/com/minecolonies/network/messages/BuildToolPlaceMessage.java
+++ b/src/main/java/com/minecolonies/network/messages/BuildToolPlaceMessage.java
@@ -166,26 +166,26 @@ public class BuildToolPlaceMessage implements IMessage, IMessageHandler<BuildToo
 
             @Nullable AbstractBuilding building = ColonyManager.getBuilding(world, buildPos);
 
-            if (building != null)
+            if (building == null)
+            {
+                Log.getLogger().error("BuildTool: building is null!");
+            }
+            else
             {
                 if (building.getTileEntity() != null)
                 {
-                    Colony colony = ColonyManager.getColony(world, buildPos);
-                    if (colony != null)
+                    final Colony colony = ColonyManager.getColony(world, buildPos);
+                    if (colony == null)
                     {
-                        building.getTileEntity().setColony(colony);
+                        Log.getLogger().info("No colony for " + player.getName());
                     }
                     else
                     {
-                        Log.getLogger().info("No colony for " + player.getName());
+                        building.getTileEntity().setColony(colony);
                     }
                 }
                 building.setStyle(style);
                 building.setRotation(rotation);
-            }
-            else
-            {
-                Log.getLogger().error("BuildTool: building is null!");
             }
         }
         else

--- a/src/main/java/com/minecolonies/network/messages/BuildToolPlaceMessage.java
+++ b/src/main/java/com/minecolonies/network/messages/BuildToolPlaceMessage.java
@@ -40,7 +40,6 @@ public class BuildToolPlaceMessage implements IMessage, IMessageHandler<BuildToo
 
     private boolean isHut;
 
-
     /**
      * Language key for missing hut message
      */
@@ -169,10 +168,10 @@ public class BuildToolPlaceMessage implements IMessage, IMessageHandler<BuildToo
 
             if (building != null)
             {
-                if(building.getTileEntity()!= null)
+                if (building.getTileEntity() != null)
                 {
-                    Colony colony=ColonyManager.getColony(world,buildPos);
-                    if(colony!=null)
+                    Colony colony = ColonyManager.getColony(world, buildPos);
+                    if (colony != null)
                     {
                         building.getTileEntity().setColony(colony);
                     }

--- a/src/main/java/com/minecolonies/network/messages/BuildToolPlaceMessage.java
+++ b/src/main/java/com/minecolonies/network/messages/BuildToolPlaceMessage.java
@@ -155,37 +155,39 @@ public class BuildToolPlaceMessage implements IMessage, IMessageHandler<BuildToo
 
         Block block = Block.getBlockFromName(Constants.MOD_ID + ":blockHut" + hut);
 
-        if (player.inventory.hasItemStack(new ItemStack(block))
-              && EventHandler.onBlockHutPlaced(world, player, block, buildPos))
+        if (player.inventory.hasItemStack(new ItemStack(block)))
         {
-            world.destroyBlock(buildPos, true);
-            world.setBlockState(buildPos, block.getDefaultState());
-            block.onBlockPlacedBy(world, buildPos, world.getBlockState(buildPos), player, null);
-
-            player.inventory.clearMatchingItems(Item.getItemFromBlock(block), -1, 1, null);
-
-            @Nullable AbstractBuilding building = ColonyManager.getBuilding(world, buildPos);
-
-            if (building == null)
+            if (EventHandler.onBlockHutPlaced(world, player, block, buildPos))
             {
-                Log.getLogger().error("BuildTool: building is null!");
-            }
-            else
-            {
-                if (building.getTileEntity() != null)
+                world.destroyBlock(buildPos, true);
+                world.setBlockState(buildPos, block.getDefaultState());
+                block.onBlockPlacedBy(world, buildPos, world.getBlockState(buildPos), player, null);
+
+                player.inventory.clearMatchingItems(Item.getItemFromBlock(block), -1, 1, null);
+
+                @Nullable AbstractBuilding building = ColonyManager.getBuilding(world, buildPos);
+
+                if (building == null)
                 {
-                    final Colony colony = ColonyManager.getColony(world, buildPos);
-                    if (colony == null)
-                    {
-                        Log.getLogger().info("No colony for " + player.getName());
-                    }
-                    else
-                    {
-                        building.getTileEntity().setColony(colony);
-                    }
+                    Log.getLogger().error("BuildTool: building is null!");
                 }
-                building.setStyle(style);
-                building.setRotation(rotation);
+                else
+                {
+                    if (building.getTileEntity() != null)
+                    {
+                        final Colony colony = ColonyManager.getColony(world, buildPos);
+                        if (colony == null)
+                        {
+                            Log.getLogger().info("No colony for " + player.getName());
+                        }
+                        else
+                        {
+                            building.getTileEntity().setColony(colony);
+                        }
+                    }
+                    building.setStyle(style);
+                    building.setRotation(rotation);
+                }
             }
         }
         else

--- a/src/main/java/com/minecolonies/tileentities/TileEntityColonyBuilding.java
+++ b/src/main/java/com/minecolonies/tileentities/TileEntityColonyBuilding.java
@@ -114,28 +114,32 @@ public class TileEntityColonyBuilding extends TileEntityChest
     {
         if (colony == null)
         {
-            if (colonyId != 0)
+            if (colonyId == 0)
             {
-                colony = ColonyManager.getColony(colonyId);
+                colony = ColonyManager.getColony(worldObj, this.getPos());
             }
             else
             {
-                throw new IllegalStateException(String.format("TileEntityColonyBuilding at %s:[%d,%d,%d] has no colonyId",
-                  worldObj.getWorldInfo().getWorldName(), pos.getX(), pos.getY(), pos.getZ()));
+                colony = ColonyManager.getColony(colonyId);
             }
 
-//            else if (worldObj != null)
-//            {
-//                throw new IllegalStateException(String.format("TileEntityColonyBuilding at %s:[%d,%d,%d] has no colonyId",
-//                        worldObj.getWorldInfo().getWorldName(), xCoord, yCoord, zCoord));
-//
-//                colony = ColonyManager.getColony(worldObj, xCoord, yCoord, zCoord);
-//
-//                if (colony != null)
-//                {
-//                    colonyId = colony.getID();
-//                }
-//            }
+            if (colony == null)
+            {
+                //we tried to update the colony it is still missing... so we...
+                if (worldObj == null || worldObj.isRemote)
+                {
+                    Log.getLogger()
+                      .warn(String.format("TileEntityColonyBuilding at :[%d,%d,%d] had no colony.  It could be a previewed building.",
+                        pos.getX(), pos.getY(), pos.getZ()));
+                }
+                else
+                {
+                    //log on the server
+                    Log.getLogger()
+                      .warn(String.format("TileEntityColonyBuilding at %s:[%d,%d,%d] had colony.",
+                        worldObj.getWorldInfo().getWorldName(), pos.getX(), pos.getY(), pos.getZ()));
+                }
+            }
         }
 
         if (building == null && colony != null)
@@ -188,12 +192,11 @@ public class TileEntityColonyBuilding extends TileEntityChest
     public void readFromNBT(NBTTagCompound compound)
     {
         super.readFromNBT(compound);
-        if (!compound.hasKey(TAG_COLONY))
+        if (compound.hasKey(TAG_COLONY))
         {
-            throw new IllegalStateException(String.format("TileEntityColonyBuilding at %s:[%d,%d,%d] missing COLONY tag.",
-              worldObj.getWorldInfo().getWorldName(), pos.getX(), pos.getY(), pos.getZ()));
+            colonyId = compound.getInteger(TAG_COLONY);
         }
-        colonyId = compound.getInteger(TAG_COLONY);
+
         updateColonyReferences();
     }
 
@@ -226,9 +229,10 @@ public class TileEntityColonyBuilding extends TileEntityChest
     public NBTTagCompound writeToNBT(@NotNull NBTTagCompound compound)
     {
         super.writeToNBT(compound);
-        if (colonyId == 0)
+        if (colonyId == 0 && colony == null)
         {
-            throw new IllegalStateException(String.format("TileEntityColonyBuilding at %s:[%d,%d,%d] has no colonyId; %s colony reference.",
+            colony = ColonyManager.getColony(worldObj, this.getPosition());
+            Log.getLogger().fatal(String.format("TileEntityColonyBuilding at %s:[%d,%d,%d] has no colonyId; %s colony reference.",
               worldObj.getWorldInfo().getWorldName(), pos.getX(), pos.getY(), pos.getZ(),
               colony == null ? "NO" : "valid"));
         }

--- a/src/main/java/com/minecolonies/tileentities/TileEntityColonyBuilding.java
+++ b/src/main/java/com/minecolonies/tileentities/TileEntityColonyBuilding.java
@@ -6,6 +6,8 @@ import com.minecolonies.colony.ColonyView;
 import com.minecolonies.colony.buildings.AbstractBuilding;
 import com.minecolonies.colony.materials.MaterialSystem;
 import com.minecolonies.colony.permissions.Permissions;
+import com.minecolonies.util.Log;
+import com.sun.javafx.binding.Logging;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -79,11 +81,11 @@ public class TileEntityColonyBuilding extends TileEntityChest
 
         if (!worldObj.isRemote && colonyId == 0)
         {
-            throw new IllegalStateException(String.format("TileEntityColonyBuilding at %s:[%d,%d,%d] has no colonyId",
-                    worldObj.getWorldInfo().getWorldName(),
-                    pos.getX(),
-                    pos.getY(),
-                    pos.getZ()));
+            Logging.getLogger().severe(String.format("TileEntityColonyBuilding at %s:[%d,%d,%d] has no colonyId",
+              worldObj.getWorldInfo().getWorldName(),
+              pos.getX(),
+              pos.getY(),
+              pos.getZ()));
         }
     }
 

--- a/src/main/java/com/minecolonies/tileentities/TileEntityColonyBuilding.java
+++ b/src/main/java/com/minecolonies/tileentities/TileEntityColonyBuilding.java
@@ -30,12 +30,12 @@ public class TileEntityColonyBuilding extends TileEntityChest
     /**
      * The colony id.
      */
-    private              int    colonyId   = 0;
+    private int colonyId = 0;
 
     /**
      * The colony.
      */
-    private Colony           colony;
+    private Colony colony;
 
     /**
      * The building the tileEntity belongs to.
@@ -142,7 +142,7 @@ public class TileEntityColonyBuilding extends TileEntityChest
         if (building == null && colony != null)
         {
             building = colony.getBuilding(getPosition());
-            if (building != null  && (worldObj == null || !worldObj.isRemote))
+            if (building != null && (worldObj == null || !worldObj.isRemote))
             {
                 building.setTileEntity(this);
             }

--- a/src/main/java/com/minecolonies/tileentities/TileEntityColonyBuilding.java
+++ b/src/main/java/com/minecolonies/tileentities/TileEntityColonyBuilding.java
@@ -81,7 +81,7 @@ public class TileEntityColonyBuilding extends TileEntityChest
 
         if (!worldObj.isRemote && colonyId == 0)
         {
-            Logging.getLogger().severe(String.format("TileEntityColonyBuilding at %s:[%d,%d,%d] has no colonyId",
+            Log.getLogger().fatal(String.format("TileEntityColonyBuilding at %s:[%d,%d,%d] has no colonyId",
               worldObj.getWorldInfo().getWorldName(),
               pos.getX(),
               pos.getY(),

--- a/src/main/java/com/minecolonies/tileentities/TileEntityColonyBuilding.java
+++ b/src/main/java/com/minecolonies/tileentities/TileEntityColonyBuilding.java
@@ -7,7 +7,6 @@ import com.minecolonies.colony.buildings.AbstractBuilding;
 import com.minecolonies.colony.materials.MaterialSystem;
 import com.minecolonies.colony.permissions.Permissions;
 import com.minecolonies.util.Log;
-import com.sun.javafx.binding.Logging;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;


### PR DESCRIPTION
Closes #160 build tool crashes when placing buildings

# Changes proposed in this pull request:
- Minor changes to lgging around creation of colonies and buildings
- Removes server side exception we threw and replaced it with a server log
- Set the colony on the abstract building in the BuildToolPlaceMessage

Review please @Minecolonies/maintainers

…id colony.