### PR TITLE
limit renaming colony name to 25 characters.

### DIFF
--- a/src/main/java/com/minecolonies/network/messages/TownHallRenameMessage.java
+++ b/src/main/java/com/minecolonies/network/messages/TownHallRenameMessage.java
@@ -16,6 +16,8 @@ public class TownHallRenameMessage implements IMessage, IMessageHandler<TownHall
 {
     private int    colonyId;
     private String name;
+    private static final int MAX_NAME_LENGTH = 25;
+    private static final int SUBSTRING_LENGTH = 24;
 
     public TownHallRenameMessage() {}
 
@@ -28,7 +30,7 @@ public class TownHallRenameMessage implements IMessage, IMessageHandler<TownHall
     public TownHallRenameMessage(@NotNull ColonyView colony, String name)
     {
         this.colonyId = colony.getID();
-        this.name = (name.length() <= 25)? name : name.substring(0, 24);
+        this.name = (name.length() <= MAX_NAME_LENGTH)? name : name.substring(0, SUBSTRING_LENGTH);
     }
 
     @Override
@@ -53,6 +55,7 @@ public class TownHallRenameMessage implements IMessage, IMessageHandler<TownHall
 
         if (colony != null)
         {
+            this.name = (name.length() <= 25)? name : name.substring(0, 24);
             colony.setName(message.name);
             MineColonies.getNetwork().sendToAll(message);
         }

--- a/src/main/java/com/minecolonies/network/messages/TownHallRenameMessage.java
+++ b/src/main/java/com/minecolonies/network/messages/TownHallRenameMessage.java
@@ -17,7 +17,7 @@ public class TownHallRenameMessage implements IMessage, IMessageHandler<TownHall
     private int    colonyId;
     private String name;
     private static final int MAX_NAME_LENGTH = 25;
-    private static final int SUBSTRING_LENGTH = 24;
+    private static final int SUBSTRING_LENGTH = MAX_NAME_LENGTH - 1;
 
     public TownHallRenameMessage() {}
 
@@ -55,7 +55,7 @@ public class TownHallRenameMessage implements IMessage, IMessageHandler<TownHall
 
         if (colony != null)
         {
-            this.name = (name.length() <= 25)? name : name.substring(0, 24);
+            this.name = (name.length() <= MAX_NAME_LENGTH)? name : name.substring(0, SUBSTRING_LENGTH);
             colony.setName(message.name);
             MineColonies.getNetwork().sendToAll(message);
         }

--- a/src/main/java/com/minecolonies/network/messages/TownHallRenameMessage.java
+++ b/src/main/java/com/minecolonies/network/messages/TownHallRenameMessage.java
@@ -28,7 +28,7 @@ public class TownHallRenameMessage implements IMessage, IMessageHandler<TownHall
     public TownHallRenameMessage(@NotNull ColonyView colony, String name)
     {
         this.colonyId = colony.getID();
-        this.name = name;
+        this.name = (name.length() <= 25)? name : name.substring(0, 24);
     }
 
     @Override

--- a/src/main/resources/assets/minecolonies/gui/windowTownHallNameEntry.xml
+++ b/src/main/resources/assets/minecolonies/gui/windowTownHallNameEntry.xml
@@ -2,7 +2,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="file:../../../../java/com/blockout/blockOut.xsd">
     <label size="100% 11" pos="0 100" textalign="TopMiddle" color="white" label="$(com.minecolonies.gui.townHall.rename.title)"/>
-    <input id="name" size="150 18" pos="135 110" maxlength="128"/>
+    <input id="name" size="150 18" pos="135 110" maxlength="25"/>
     <button id="done" size="200 20" pos="110 170" label="$(gui.done)"/>
     <button id="cancel" size="200 20" pos="110 194" label="$(gui.cancel)"/>
 </window>


### PR DESCRIPTION
Closes #204 

# Changes proposed in this pull request:
-limit renaming colony name to 25 characters.

Review please @Minecolonies/maintainers

