### PR TITLE
Feature/pathfinder optimization

### DIFF
--- a/src/main/java/com/minecolonies/entity/pathfinding/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/entity/pathfinding/AbstractPathJob.java
@@ -35,6 +35,13 @@ public abstract class AbstractPathJob implements Callable<Path>
     private static final   int    SHIFT_WEST            = 2;
     private static final   int    SHIFT_NORTH           = 3;
     private static final   int    SHIFT_EAST            = 4;
+    private static final BlockPos BLOCKPOS_IDENTITY = new BlockPos(0, 0, 0);
+    private static final BlockPos BLOCKPOS_UP = new BlockPos(0, 1, 0);
+    private static final BlockPos BLOCKPOS_DOWN = new BlockPos(0, -1, 0);
+    private static final BlockPos BLOCKPOS_NORTH = new BlockPos(0, 0, -1);
+    private static final BlockPos BLOCKPOS_SOUTH = new BlockPos(0, 0, 1);
+    private static final BlockPos BLOCKPOS_EAST = new BlockPos(1, 0, 0);
+    private static final BlockPos BLOCKPOS_WEST = new BlockPos(-1, 0, 0);
     @Nullable
     protected static Set<Node>    lastDebugNodesVisited;
     @Nullable
@@ -422,14 +429,6 @@ public abstract class AbstractPathJob implements Callable<Path>
         return false;
     }
 
-    private static BlockPos BLOCKPOS_IDENTITY = new BlockPos(0, 0, 0);
-    private static BlockPos BLOCKPOS_UP = new BlockPos(0, 1, 0);
-    private static BlockPos BLOCKPOS_DOWN = new BlockPos(0, -1, 0);
-    private static BlockPos BLOCKPOS_NORTH = new BlockPos(0, 0, -1);
-    private static BlockPos BLOCKPOS_SOUTH = new BlockPos(0, 0, 1);
-    private static BlockPos BLOCKPOS_EAST = new BlockPos(1, 0, 0);
-    private static BlockPos BLOCKPOS_WEST = new BlockPos(-1, 0, 0);
-
     private void walkCurrentNode(@NotNull Node currentNode)
     {
         BlockPos dPos = BLOCKPOS_IDENTITY;
@@ -787,7 +786,7 @@ public abstract class AbstractPathJob implements Callable<Path>
 
         //  Do we have something to stand on in the target space?
         final IBlockState below = world.getBlockState(pos.down());
-        SurfaceType walkability = isWalkableSurface(below);
+        final SurfaceType walkability = isWalkableSurface(below);
         if (walkability == SurfaceType.WALKABLE)
         {
             //  Level path

--- a/src/main/java/com/minecolonies/entity/pathfinding/AbstractPathJob.java
+++ b/src/main/java/com/minecolonies/entity/pathfinding/AbstractPathJob.java
@@ -248,23 +248,6 @@ public abstract class AbstractPathJob implements Callable<Path>
     }
 
     /**
-     * Generate a pseudo-unique key for identifying a given node by it's coordinates
-     * Encodes the lowest 12 bits of x,z and all useful bits of y.
-     * This creates unique keys for all blocks within a 4096x256x4096 cube, which is FAR
-     * bigger volume than one should attempt to pathfind within
-     * This version takes independent x,y,z for performance
-     *
-     * @param x,y,z Position to generate key from
-     * @return key for node in map
-     */
-    private static int computeNodeKey(int x, int y, int z)
-    {
-        return ((x & 0xFFF) << 20) |
-                ((y & 0xFF) << 12) |
-                (z & 0xFFF);
-    }
-
-    /**
      * Compute the cost (immediate 'g' value) of moving from the parent space to the new space,
      *
      * @param parent     The parent node being moved from
@@ -684,7 +667,8 @@ public abstract class AbstractPathJob implements Callable<Path>
         if (pos.getY() != newY)
         {
             //  Has this node been visited?
-            nodeKey = computeNodeKey(pos.getX(), newY, pos.getZ());
+            pos = new BlockPos(pos.getX(), newY, pos.getZ());
+            nodeKey = computeNodeKey(pos);
             node = nodesVisited.get(nodeKey);
             if (nodeClosed(node))
             {

--- a/src/main/java/com/minecolonies/entity/pathfinding/PathNavigate.java
+++ b/src/main/java/com/minecolonies/entity/pathfinding/PathNavigate.java
@@ -5,10 +5,7 @@ import com.minecolonies.util.BlockPosUtil;
 import com.minecolonies.util.Log;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
-import net.minecraft.pathfinding.Path;
-import net.minecraft.pathfinding.PathFinder;
-import net.minecraft.pathfinding.PathNavigateGround;
-import net.minecraft.pathfinding.PathPoint;
+import net.minecraft.pathfinding.*;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
@@ -37,14 +34,12 @@ public class PathNavigate extends PathNavigateGround
     @Nullable
     private PathResult   pathResult;
 
-    private boolean canEnterDoors    = false;
-    private boolean canBreakDoors    = false;
-    private boolean canSwim          = false;
-
     public PathNavigate(@NotNull EntityLiving entity, World world)
     {
         super(entity, world);
         this.entity = entity;
+
+        this.nodeProcessor = new WalkNodeProcessor();
     }
 
     @Nullable
@@ -74,18 +69,13 @@ public class PathNavigate extends PathNavigateGround
         return null;
     }
 
-    @Override
-    protected boolean isDirectPathBetweenPoints(final Vec3d Vec3d, final Vec3d Vec3d1, final int i, final int i1, final int i2)
-    {
-        //we don't use, so it doesn't matter
-        return false;
-    }
-
-    @Override
-    public void setBreakDoors(boolean canBreakDoors)
-    {
-        this.canBreakDoors = canBreakDoors;
-    }
+    //  Re-enable this if path shortcutting becomes a problem; then entities will move more rigidly along world grid
+//    @Override
+//    protected boolean isDirectPathBetweenPoints(final Vec3d Vec3d, final Vec3d Vec3d1, final int i, final int i1, final int i2)
+//    {
+//        //we don't use, so it doesn't matter
+//        return false;
+//    }
 
     public double getSpeed()
     {
@@ -222,7 +212,7 @@ public class PathNavigate extends PathNavigateGround
             {
                 Vec3d vec3 = this.getPath().getPosition(this.entity);
 
-                if (vec3.squareDistanceTo(new Vec3d(entity.posX, vec3.yCoord, entity.posZ)) < 0.1)
+                if (vec3.squareDistanceTo(entity.posX, vec3.yCoord, entity.posZ) < 0.1)
                 {
                     //This way he is less nervous and gets up the ladder
                     double newSpeed = 0.05;
@@ -385,45 +375,8 @@ public class PathNavigate extends PathNavigateGround
           null, speed);
     }
 
-    //We don't use any of these, but they need to be overriden.
-    /*@Override
-    public void setAvoidsWater(boolean avoidsWater)
-    {
-        this.shouldAvoidWater = avoidsWater;
-    }
-
-    @Override
-    public boolean getAvoidsWater()
-    {
-        return shouldAvoidWater;
-    }*/
-
     public boolean isUnableToReachDestination()
     {
         return pathResult != null && pathResult.failedToReachDestination();
-    }
-
-    @Override
-    public void setEnterDoors(boolean canEnterDoors)
-    {
-        this.canEnterDoors = canEnterDoors;
-    }
-
-    @Override
-    public boolean getEnterDoors()
-    {
-        return canEnterDoors;
-    }
-
-    @Override
-    public void setCanSwim(boolean canSwim)
-    {
-        this.canSwim = canSwim;
-    }
-
-    @Override
-    public boolean getCanSwim()
-    {
-        return canSwim;
     }
 }


### PR DESCRIPTION
Re-enable path shortcutting for more natural entity pathfinding (easy to disable if it causes problems)

Optimizations to the Pathfinder:
- Increase chunk cache space to include more space around start/end
- isWalkableSurface called twice in a row when only needs to be called once and result tested twice
- Use static BlockPos objects for all 6 direction deltas, rather than allocating them
- computeNodeKey variant added that takes independent x,y,z
- Conditionally call addNodeToDebug based on debugDrawEnabled, rather than testing in function
- Fix bug introduced in previous commit, when Y along path changed, it did not properly adjust the Y of the node
- Remove unnecessary overrides
- Remove unnecessary "new" and pass coords directly (optimization)
