### PR TITLE
Feature/#185 delete colony

### DIFF
--- a/src/main/java/com/minecolonies/colony/ColonyManager.java
+++ b/src/main/java/com/minecolonies/colony/ColonyManager.java
@@ -107,7 +107,7 @@ public final class ColonyManager
             coloniesByWorld.get(colony.getDimension()).remove(colony);
             final Set<World> colonyWorlds = new HashSet<>();
             Log.getLogger().info("Removing citizens for " + id);
-            for (CitizenData citizenData : new ArrayList<>(colony.getCitizens().values()))
+            for (final CitizenData citizenData : new ArrayList<>(colony.getCitizens().values()))
             {
                 Log.getLogger().info("Kill Citizen " + citizenData.getName());
                 World world = citizenData.getCitizenEntity().getEntityWorld();
@@ -115,13 +115,13 @@ public final class ColonyManager
                 colonyWorlds.add(world);
             }
             Log.getLogger().info("Removing buildings for " + id);
-            for (AbstractBuilding building : new ArrayList<>(colony.getBuildings().values()))
+            for (final AbstractBuilding building : new ArrayList<>(colony.getBuildings().values()))
             {
 
                 final BlockPos location = building.getLocation();
                 Log.getLogger().info("Delete Building at " + location);
                 building.destroy();
-                for (World world : colonyWorlds)
+                for (final World world : colonyWorlds)
                 {
                     Log.getLogger().info("Try out World " + world.getProviderName());
                     if (world.getBlockState(location).getBlock() instanceof AbstractBlockHut)

--- a/src/main/java/com/minecolonies/colony/IColony.java
+++ b/src/main/java/com/minecolonies/colony/IColony.java
@@ -54,4 +54,11 @@ public interface IColony
      * @return whether or not the colony has a town hall.
      */
     boolean hasTownHall();
+
+    /**
+     * returns this colonies unique id.
+     *
+     * @return an int representing the id.
+     */
+    int getID();
 }

--- a/src/main/java/com/minecolonies/commands/CitizensCommand.java
+++ b/src/main/java/com/minecolonies/commands/CitizensCommand.java
@@ -16,7 +16,7 @@ public class CitizensCommand extends AbstractSplitCommand
 
     private final ImmutableMap<String, ISubCommand> subCommands =
       new ImmutableMap.Builder<String, ISubCommand>()
-        .put(ListCitizens.DESC, new ListCitizens(MinecoloniesCommand.DESC, CitizensCommand.DESC, ListCitizens.DESC))
+        .put(ListCitizensCommand.DESC, new ListCitizensCommand(MinecoloniesCommand.DESC, CitizensCommand.DESC, ListCitizensCommand.DESC))
         .build();
 
     /**

--- a/src/main/java/com/minecolonies/commands/ColoniesCommand.java
+++ b/src/main/java/com/minecolonies/commands/ColoniesCommand.java
@@ -16,7 +16,7 @@ public class ColoniesCommand extends AbstractSplitCommand
 
     private final ImmutableMap<String, ISubCommand> subCommands =
       new ImmutableMap.Builder<String, ISubCommand>()
-        .put("list", new ListColonies(MinecoloniesCommand.DESC, ColoniesCommand.DESC, "list"))
+        .put("list", new ListColoniesCommand(MinecoloniesCommand.DESC, ColoniesCommand.DESC, "list"))
         .build();
 
     /**

--- a/src/main/java/com/minecolonies/commands/ColonyCommand.java
+++ b/src/main/java/com/minecolonies/commands/ColonyCommand.java
@@ -19,6 +19,7 @@ public class ColonyCommand extends AbstractSplitCommand
         .put(KillCitizenCommand.DESC, new KillCitizenCommand(MinecoloniesCommand.DESC, ColonyCommand.DESC, KillCitizenCommand.DESC))
         .put(RespawnCitizenCommand.DESC, new RespawnCitizenCommand(MinecoloniesCommand.DESC, ColonyCommand.DESC, RespawnCitizenCommand.DESC))
         .put(ShowColonyInfoCommand.DESC, new ShowColonyInfoCommand(MinecoloniesCommand.DESC, ColonyCommand.DESC, ShowColonyInfoCommand.DESC))
+        .put(DeleteColonyCommand.DESC, new DeleteColonyCommand(MinecoloniesCommand.DESC, ColonyCommand.DESC, DeleteColonyCommand.DESC))
         .build();
 
     /**

--- a/src/main/java/com/minecolonies/commands/ColonyCommand.java
+++ b/src/main/java/com/minecolonies/commands/ColonyCommand.java
@@ -16,9 +16,9 @@ public class ColonyCommand extends AbstractSplitCommand
 
     private final ImmutableMap<String, ISubCommand> subCommands =
       new ImmutableMap.Builder<String, ISubCommand>()
-        .put(KillCitizen.DESC, new KillCitizen(MinecoloniesCommand.DESC, ColonyCommand.DESC, KillCitizen.DESC))
-        .put(RespawnCitizen.DESC, new RespawnCitizen(MinecoloniesCommand.DESC, ColonyCommand.DESC, RespawnCitizen.DESC))
-        .put(ColonyInfo.DESC, new ColonyInfo(MinecoloniesCommand.DESC, ColonyCommand.DESC, ColonyInfo.DESC))
+        .put(KillCitizenCommand.DESC, new KillCitizenCommand(MinecoloniesCommand.DESC, ColonyCommand.DESC, KillCitizenCommand.DESC))
+        .put(RespawnCitizenCommand.DESC, new RespawnCitizenCommand(MinecoloniesCommand.DESC, ColonyCommand.DESC, RespawnCitizenCommand.DESC))
+        .put(ShowColonyInfoCommand.DESC, new ShowColonyInfoCommand(MinecoloniesCommand.DESC, ColonyCommand.DESC, ShowColonyInfoCommand.DESC))
         .build();
 
     /**

--- a/src/main/java/com/minecolonies/commands/DeleteColonyCommand.java
+++ b/src/main/java/com/minecolonies/commands/DeleteColonyCommand.java
@@ -1,0 +1,148 @@
+package com.minecolonies.commands;
+
+import com.minecolonies.colony.Colony;
+import com.minecolonies.colony.ColonyManager;
+import com.minecolonies.colony.IColony;
+import com.mojang.authlib.GameProfile;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextComponentString;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * List all colonies.
+ */
+public class DeleteColonyCommand extends AbstractSingleCommand
+{
+
+    public static final  String DESC                       = "info";
+    private static final String ID_TEXT                    = "§2ID: §f";
+    private static final String NAME_TEXT                  = "§2 Name: §f";
+    private static final String MAYOR_TEXT                 = "§2Mayor: §f";
+    private static final String COORDINATES_TEXT           = "§2Coordinates: §f";
+    private static final String COORDINATES_XYZ            = "§4x=§f%s §4y=§f%s §4z=§f%s";
+    private static final String CITIZENS                   = "§2Citizens: §f";
+    private static final String NO_COLONY_FOUND_MESSAGE    = "Colony with mayor %s not found.";
+    private static final String NO_COLONY_FOUND_MESSAGE_ID = "Colony with ID %d not found.";
+
+    /**
+     * Initialize this SubCommand with it's parents.
+     *
+     * @param parents an array of all the parents.
+     */
+    public DeleteColonyCommand(@NotNull final String... parents)
+    {
+        super(parents);
+    }
+
+    @NotNull
+    @Override
+    public String getCommandUsage(@NotNull final ICommandSender sender)
+    {
+        return super.getCommandUsage(sender) + "<ColonyId|OwnerName>";
+    }
+
+    @Override
+    public void execute(@NotNull final MinecraftServer server, @NotNull final ICommandSender sender, @NotNull final String... args) throws CommandException
+    {
+        int colonyId = -1;
+        UUID mayorID = sender.getCommandSenderEntity().getUniqueID();
+
+        if (args.length != 0)
+        {
+            try
+            {
+                colonyId = Integer.parseInt(args[0]);
+            }
+            catch (NumberFormatException e)
+            {
+                mayorID = getUUIDFromName(sender, args);
+            }
+        }
+
+        final IColony tempColony;
+        if (colonyId == -1)
+        {
+            tempColony = ColonyManager.getIColonyByOwner(sender.getEntityWorld(), mayorID);
+        }
+        else
+        {
+            tempColony = ColonyManager.getColony(colonyId);
+        }
+
+        if (tempColony == null)
+        {
+            if (colonyId == -1)
+            {
+                sender.addChatMessage(new TextComponentString(String.format(NO_COLONY_FOUND_MESSAGE, args[0])));
+            }
+            else
+            {
+                sender.addChatMessage(new TextComponentString(String.format(NO_COLONY_FOUND_MESSAGE_ID, colonyId)));
+            }
+            return;
+        }
+
+        final Colony colony = ColonyManager.getColony(sender.getEntityWorld(), tempColony.getCenter());
+        if (colony == null)
+        {
+            if (colonyId == -1)
+            {
+                sender.addChatMessage(new TextComponentString(String.format(NO_COLONY_FOUND_MESSAGE, args[0])));
+            }
+            else
+            {
+                sender.addChatMessage(new TextComponentString(String.format(NO_COLONY_FOUND_MESSAGE_ID, colonyId)));
+            }
+            return;
+        }
+
+        final BlockPos position = colony.getCenter();
+        sender.addChatMessage(new TextComponentString(ID_TEXT + colony.getID() + NAME_TEXT + colony.getName()));
+        final String mayor = colony.getPermissions().getOwnerName();
+        sender.addChatMessage(new TextComponentString(MAYOR_TEXT + mayor));
+        sender.addChatMessage(new TextComponentString(CITIZENS + colony.getCitizens().size() + "/" + colony.getMaxCitizens()));
+        sender.addChatMessage(new TextComponentString(COORDINATES_TEXT + String.format(COORDINATES_XYZ, position.getX(), position.getY(), position.getZ())));
+    }
+
+    private static UUID getUUIDFromName(@NotNull final ICommandSender sender, @NotNull final String... args)
+    {
+        final MinecraftServer tempServer = sender.getEntityWorld().getMinecraftServer();
+        if (tempServer != null)
+        {
+            final GameProfile profile = tempServer.getPlayerProfileCache().getGameProfileForUsername(args[0]);
+            if (profile != null)
+            {
+                return profile.getId();
+            }
+        }
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public List<String> getTabCompletionOptions(
+                                                 @NotNull final MinecraftServer server,
+                                                 @NotNull final ICommandSender sender,
+                                                 @NotNull final String[] args,
+                                                 @Nullable final BlockPos pos)
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isUsernameIndex(@NotNull final String[] args, final int index)
+    {
+        return index == 0
+                 && args.length > 0
+                 && !args[0].isEmpty()
+                 && getIthArgument(args, 0, Integer.MAX_VALUE) == Integer.MAX_VALUE;
+    }
+}

--- a/src/main/java/com/minecolonies/commands/DeleteColonyCommand.java
+++ b/src/main/java/com/minecolonies/commands/DeleteColonyCommand.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 public class DeleteColonyCommand extends AbstractSingleCommand
 {
 
-    public static final  String DESC                       = "info";
+    public static final  String DESC                       = "delete";
     private static final String ID_TEXT                    = "§2ID: §f";
     private static final String NAME_TEXT                  = "§2 Name: §f";
     private static final String MAYOR_TEXT                 = "§2Mayor: §f";
@@ -53,7 +53,7 @@ public class DeleteColonyCommand extends AbstractSingleCommand
     public void execute(@NotNull final MinecraftServer server, @NotNull final ICommandSender sender, @NotNull final String... args) throws CommandException
     {
         int colonyId = -1;
-        UUID mayorID = sender.getCommandSenderEntity().getUniqueID();
+        UUID mayorID = null;
 
         if (args.length != 0)
         {
@@ -67,30 +67,16 @@ public class DeleteColonyCommand extends AbstractSingleCommand
             }
         }
 
-        final IColony tempColony;
+        final IColony colony;
         if (colonyId == -1)
         {
-            tempColony = ColonyManager.getIColonyByOwner(sender.getEntityWorld(), mayorID);
+            colony = ColonyManager.getIColonyByOwner(sender.getEntityWorld(), mayorID);
         }
         else
         {
-            tempColony = ColonyManager.getColony(colonyId);
+            colony = ColonyManager.getColony(colonyId);
         }
 
-        if (tempColony == null)
-        {
-            if (colonyId == -1)
-            {
-                sender.addChatMessage(new TextComponentString(String.format(NO_COLONY_FOUND_MESSAGE, args[0])));
-            }
-            else
-            {
-                sender.addChatMessage(new TextComponentString(String.format(NO_COLONY_FOUND_MESSAGE_ID, colonyId)));
-            }
-            return;
-        }
-
-        final Colony colony = ColonyManager.getColony(sender.getEntityWorld(), tempColony.getCenter());
         if (colony == null)
         {
             if (colonyId == -1)
@@ -103,13 +89,8 @@ public class DeleteColonyCommand extends AbstractSingleCommand
             }
             return;
         }
+        server.addScheduledTask(() -> ColonyManager.deleteColony(colony.getID()));
 
-        final BlockPos position = colony.getCenter();
-        sender.addChatMessage(new TextComponentString(ID_TEXT + colony.getID() + NAME_TEXT + colony.getName()));
-        final String mayor = colony.getPermissions().getOwnerName();
-        sender.addChatMessage(new TextComponentString(MAYOR_TEXT + mayor));
-        sender.addChatMessage(new TextComponentString(CITIZENS + colony.getCitizens().size() + "/" + colony.getMaxCitizens()));
-        sender.addChatMessage(new TextComponentString(COORDINATES_TEXT + String.format(COORDINATES_XYZ, position.getX(), position.getY(), position.getZ())));
     }
 
     private static UUID getUUIDFromName(@NotNull final ICommandSender sender, @NotNull final String... args)

--- a/src/main/java/com/minecolonies/commands/DeleteColonyCommand.java
+++ b/src/main/java/com/minecolonies/commands/DeleteColonyCommand.java
@@ -1,6 +1,5 @@
 package com.minecolonies.commands;
 
-import com.minecolonies.colony.Colony;
 import com.minecolonies.colony.ColonyManager;
 import com.minecolonies.colony.IColony;
 import com.mojang.authlib.GameProfile;
@@ -23,12 +22,6 @@ public class DeleteColonyCommand extends AbstractSingleCommand
 {
 
     public static final  String DESC                       = "delete";
-    private static final String ID_TEXT                    = "§2ID: §f";
-    private static final String NAME_TEXT                  = "§2 Name: §f";
-    private static final String MAYOR_TEXT                 = "§2Mayor: §f";
-    private static final String COORDINATES_TEXT           = "§2Coordinates: §f";
-    private static final String COORDINATES_XYZ            = "§4x=§f%s §4y=§f%s §4z=§f%s";
-    private static final String CITIZENS                   = "§2Citizens: §f";
     private static final String NO_COLONY_FOUND_MESSAGE    = "Colony with mayor %s not found.";
     private static final String NO_COLONY_FOUND_MESSAGE_ID = "Colony with ID %d not found.";
 

--- a/src/main/java/com/minecolonies/commands/KillCitizenCommand.java
+++ b/src/main/java/com/minecolonies/commands/KillCitizenCommand.java
@@ -19,7 +19,7 @@ import java.util.List;
 /**
  * List all colonies.
  */
-public class KillCitizen extends AbstractSingleCommand
+public class KillCitizenCommand extends AbstractSingleCommand
 {
 
     public static final  String       DESC                            = "kill";
@@ -40,7 +40,7 @@ public class KillCitizen extends AbstractSingleCommand
      *
      * @param parents an array of all the parents.
      */
-    public KillCitizen(@NotNull final String... parents)
+    public KillCitizenCommand(@NotNull final String... parents)
     {
         super(parents);
     }

--- a/src/main/java/com/minecolonies/commands/ListCitizensCommand.java
+++ b/src/main/java/com/minecolonies/commands/ListCitizensCommand.java
@@ -23,7 +23,7 @@ import java.util.List;
 /**
  * List all colonies.
  */
-public class ListCitizens extends AbstractSingleCommand
+public class ListCitizensCommand extends AbstractSingleCommand
 {
 
     public static final  String DESC                    = "list";
@@ -43,7 +43,7 @@ public class ListCitizens extends AbstractSingleCommand
      *
      * @param parents an array of all the parents.
      */
-    public ListCitizens(@NotNull final String... parents)
+    public ListCitizensCommand(@NotNull final String... parents)
     {
         super(parents);
     }

--- a/src/main/java/com/minecolonies/commands/ListColoniesCommand.java
+++ b/src/main/java/com/minecolonies/commands/ListColoniesCommand.java
@@ -20,7 +20,7 @@ import java.util.List;
 /**
  * List all colonies.
  */
-public class ListColonies extends AbstractSingleCommand
+public class ListColoniesCommand extends AbstractSingleCommand
 {
 
     private static final String ID_TEXT                = "§2ID: §f";
@@ -42,7 +42,7 @@ public class ListColonies extends AbstractSingleCommand
      *
      * @param parents an array of all the parents.
      */
-    public ListColonies(@NotNull final String... parents)
+    public ListColoniesCommand(@NotNull final String... parents)
     {
         super(parents);
     }

--- a/src/main/java/com/minecolonies/commands/RespawnCitizenCommand.java
+++ b/src/main/java/com/minecolonies/commands/RespawnCitizenCommand.java
@@ -19,7 +19,7 @@ import java.util.List;
 /**
  * List all colonies.
  */
-public class RespawnCitizen extends AbstractSingleCommand
+public class RespawnCitizenCommand extends AbstractSingleCommand
 {
 
     public static final  String DESC                            = "respawn";
@@ -36,7 +36,7 @@ public class RespawnCitizen extends AbstractSingleCommand
      *
      * @param parents an array of all the parents.
      */
-    public RespawnCitizen(@NotNull final String... parents)
+    public RespawnCitizenCommand(@NotNull final String... parents)
     {
         super(parents);
     }

--- a/src/main/java/com/minecolonies/commands/ShowColonyInfoCommand.java
+++ b/src/main/java/com/minecolonies/commands/ShowColonyInfoCommand.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 /**
  * List all colonies.
  */
-public class ColonyInfo extends AbstractSingleCommand
+public class ShowColonyInfoCommand extends AbstractSingleCommand
 {
 
     public static final  String DESC                       = "info";
@@ -37,7 +37,7 @@ public class ColonyInfo extends AbstractSingleCommand
      *
      * @param parents an array of all the parents.
      */
-    public ColonyInfo(@NotNull final String... parents)
+    public ShowColonyInfoCommand(@NotNull final String... parents)
     {
         super(parents);
     }


### PR DESCRIPTION
Closes #185 

# Changes proposed in this pull request:
- A new deleteColony method in ColonyManager to cannonically delete a colony and leave no traces
- pushed getID into IColony because we need a way to pass an IColony to ColonyManager...
  - We need to rework that system, where we only use colony...
- a new delete command to delete a colony
  - The command will only delete explicit colonyids/usernames, not your own colony

Review please @Minecolonies/maintainers
